### PR TITLE
fixed rapid flicker of prompt_contenner

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ Thanks.
 
 The go-nebulas project is licensed under the [GNU Lesser General Public License Version 3.0 (“LGPL v3”)](https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
-For the more information about licensing, please refer to [Licensing](https://github.com/nebulasio/wiki/blob/master/licensing.md) page..
+For the more information about licensing, please refer to [Licensing](https://github.com/nebulasio/wiki/blob/master/licensing.md) page.
 

--- a/contract.html
+++ b/contract.html
@@ -122,6 +122,7 @@
             left: 16%;
             margin-top: -6%;
             box-shadow:2px 2px 17px #333333;
+            pointer-events: none;
         }
 
         .call_prompt_contenner{
@@ -132,6 +133,7 @@
             left: 28%;
             margin-top: -14%;
             box-shadow:2px 2px 17px #333333;
+            pointer-events: none;
         }
 
          .function_prompt_contenner{
@@ -142,6 +144,7 @@
             left: 24%;
             margin-top: -14%;
             box-shadow:2px 2px 17px #333333;
+            pointer-events: none;
         }
 
         .CodeMirror {border: 1px solid black; font-size:13px;}
@@ -287,7 +290,7 @@
                     <div class=col>
                         <label data-i18n=contract/contract_fun></label>
                         <span id=call_prompt class=prompt><img src=img/prompt.png></span>
-                        <div id=call_prompt_contenner class="active1 call_prompt_contenner"> <b  data-i18n=contract/contract_fun_prompt></b></div>
+                        <div id=call_prompt_contenner class="active1 call_prompt_contenner"> <b data-i18n=contract/contract_fun_prompt></b></div>
                         <input class=form-control type=text id=call_args placeholder='["arg-1", "arg-2", ...]'>
                     </div>
                 </div>

--- a/contract.html
+++ b/contract.html
@@ -122,6 +122,7 @@
             left: 16%;
             margin-top: -6%;
             box-shadow:2px 2px 17px #333333;
+            background-color: #fff;
             pointer-events: none;
         }
 
@@ -133,6 +134,7 @@
             left: 28%;
             margin-top: -14%;
             box-shadow:2px 2px 17px #333333;
+            background-color: #fff;
             pointer-events: none;
         }
 
@@ -144,6 +146,7 @@
             left: 24%;
             margin-top: -14%;
             box-shadow:2px 2px 17px #333333;
+            background-color: #fff;
             pointer-events: none;
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36702053/40280684-2298978e-5c92-11e8-8ac3-3deb11d56e6b.jpeg)

Hello.
When the mouseover action in prompt image is occurred, the prompt_contenner was flickered rapidly. So I added css code `pointer-events: none;`. Additionally, I also added `background-color: #fff;`, because it looks overlapping.

thanks!